### PR TITLE
Point volunteers directly to the volunteering page

### DIFF
--- a/modules/pages/client/components/Volunteering.component.js
+++ b/modules/pages/client/components/Volunteering.component.js
@@ -47,7 +47,7 @@ export default function Volunteering() {
             <p>
               <ul className="list-inline">
                 <li>
-                  <a href="https://team.trustroots.org/">{t('Team Guide')}</a>
+                  <a href="https://team.trustroots.org/Volunteering.html">{t('Team Guide')}</a>
                 </li>
                 <li>
                   <a href="/team">{t('Meet the team')}</a>


### PR DESCRIPTION
A person who is interested in volunteering has to do many hops until they get to the information they are looking for.

https://www.trustroots.org/volunteering ->
https://team.trustroots.org/ -> 
https://team.trustroots.org/Volunteering.html

I removed the intermediate step.