### PR TITLE
Notify matrix room on PR

### DIFF
--- a/.github/workflows/message-on-pr.yml
+++ b/.github/workflows/message-on-pr.yml
@@ -1,0 +1,17 @@
+name: Send a hello world to matrix every 5 minutes
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+
+jobs:
+  ping_matrix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: send message
+        uses: s3krit/matrix-message-action@v0.0.3
+        with:
+          room_id: ${{ secrets.MATRIX_ROOM_ID }}
+          access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
+          message: "Hello, world!"
+          server: "matrix.org"

--- a/.github/workflows/message-on-pr.yml
+++ b/.github/workflows/message-on-pr.yml
@@ -1,8 +1,9 @@
-name: Send a hello world to matrix every 5 minutes
+name: Notify matrix when pull request was opened
 
 on:
-  schedule:
-    - cron: '*/5 * * * *'
+  workflow_dispatch:
+  pull_request:
+      types: [opened, reopened]
 
 jobs:
   ping_matrix:


### PR DESCRIPTION
Fixes #11 

Two secrets were added to the gh organization: 
- `MATRIX_ROOM_ID` 
- `MATRIX_ACCESS_TOKEN`

(as for now the message is sent every 5 min, to see if it works. I am going to change it to on pr)