### PR TITLE
add simplest disclaimer possible

### DIFF
--- a/public/locales/en/core.json
+++ b/public/locales/en/core.json
@@ -26,7 +26,7 @@
   "Messages": "Messages",
   "My profile": "My profile",
   "My profile, info and support": "My profile, info and support",
-  "New to Trustroots?": "New to Trustroots?",
+  "New to Trustroots?": "Under Construction: This is a fork of Trustroots for Open Hospitality Network. New to Trustroots?",
   "Next": "Next",
   "Next section": "Next section",
   "Outdoors": "Outdoors",


### PR DESCRIPTION
This just adds text to the banner at the top of the splash page. Helps differentiate fedi-trustroots from Trustroots proper per #16 