### PR TITLE
Notify matrix when an issue or discussion starts

### DIFF
--- a/.github/workflows/message-on-pr.yml
+++ b/.github/workflows/message-on-pr.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
   pull_request:
       types: [opened, reopened]
+  issues:
+      types: [opened, reopened, transferred]
+  discussion:
+      types: [opened, transferred]
 
 jobs:
   ping_matrix:


### PR DESCRIPTION
Problem: Opening an issue or starting a discussion could go unnoticed. This is where _discussion_ should happen!

Solution: With the change, in addition to pr, matrix is going to be notified when ever new issue or discussion starts.

So far matrix was notified only when a PR (from a branch) was opened. 