### PR TITLE
Notify matrix room when an issue or discussion is created.

### DIFF
--- a/.github/workflows/for-discussions.yml
+++ b/.github/workflows/for-discussions.yml
@@ -1,0 +1,18 @@
+name: Notify matrix when a discussion is started
+
+on:
+  discussion:
+      types: [opened, transferred]
+
+jobs:
+  ping_matrix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: send message for a discussion
+        uses: s3krit/matrix-message-action@v0.0.3
+        with:
+          room_id: ${{ secrets.MATRIX_ROOM_ID }}
+          access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
+          message: "${{ github.event.discussion.user.login }} has just opened an issue: _\"${{ github.event.discussion.title }}\"_\n
+          ${{ github.event.discussion.html_url }}"
+          server: "matrix.org"

--- a/.github/workflows/for-issues.yml
+++ b/.github/workflows/for-issues.yml
@@ -1,0 +1,18 @@
+name: Notify matrix when an issue is created
+
+on:
+  issues:
+    types: [opened, reopened, transferred]
+
+jobs:
+  ping_matrix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: send message for an issue
+        uses: s3krit/matrix-message-action@v0.0.3
+        with:
+          room_id: ${{ secrets.MATRIX_ROOM_ID }}
+          access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
+          message: "${{ github.event.issue.user.login }} has just opened an issue: _\"${{ github.event.issue.title }}\"_\n
+          ${{ github.event.issue.url }}"
+          server: "matrix.org"


### PR DESCRIPTION
Problem: Issues and discussions from outsiders may go unnoticed, and we (insiders) keep manually posting them to the room.

With the change, our matrix room will get a message whenever an issues or discussion is opened. There was no discussion about it before creating a PR so please comment below whatever you think about the problem itself.