### PR TITLE
Problem: the matrix notification contains api url instead of plain one.

### DIFF
--- a/.github/workflows/for-issues.yml
+++ b/.github/workflows/for-issues.yml
@@ -14,5 +14,5 @@ jobs:
           room_id: ${{ secrets.MATRIX_ROOM_ID }}
           access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
           message: "${{ github.event.issue.user.login }} has just opened an issue: _\"${{ github.event.issue.title }}\"_\n
-          ${{ github.event.issue.url }}"
+          ${{ github.event.issue.html_url }}"
           server: "matrix.org"


### PR DESCRIPTION
Solution: use html_url instead of url.

See sample request-response here: https://docs.github.com/en/rest/reference/issues

(no issue for this)