### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "influx": "5.9.2",
     "juice": "8.0.0",
     "leaflet": "1.7.1",
-    "leaflet-active-area": "git+https://github.com/Mappy/Leaflet-active-area.git#f09574a3eb7fdce3a6778e4822955c6416415e43",
+    "leaflet-active-area": "1.1.3",
     "lodash": "4.17.21",
     "mapbox-gl": "1.13.1",
     "medium-editor": "5.23.3",


### PR DESCRIPTION
Remove ssh github link of leaflet-active-area dependency since this breaks the build.

Have not tested this locally, hope I can run this through CI to see if this unbreaks our build.

#### Proposed Changes

Remove ssh link to github repo from deps

Fixes #

Broken CI build
