### PR TITLE
Replace url with a link for matrix notifications

### DIFF
--- a/.github/workflows/for-discussions.yml
+++ b/.github/workflows/for-discussions.yml
@@ -13,6 +13,5 @@ jobs:
         with:
           room_id: ${{ secrets.MATRIX_ROOM_ID }}
           access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
-          message: "${{ github.event.discussion.user.login }} has just opened an issue: _\"${{ github.event.discussion.title }}\"_\n
-          ${{ github.event.discussion.html_url }}"
+          message: "${{ github.event.discussion.user.login }} has just opened an issue: [${{ github.event.discussion.title }}](${{ github.event.discussion.html_url }})"
           server: "matrix.org"

--- a/.github/workflows/for-issues.yml
+++ b/.github/workflows/for-issues.yml
@@ -13,6 +13,5 @@ jobs:
         with:
           room_id: ${{ secrets.MATRIX_ROOM_ID }}
           access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
-          message: "${{ github.event.issue.user.login }} has just opened an issue: _\"${{ github.event.issue.title }}\"_\n
-          ${{ github.event.issue.html_url }}"
+          message: "${{ github.event.issue.user.login }} has just opened an issue: [${{ github.event.issue.title }}](${{ github.event.issue.html_url }})"
           server: "matrix.org"


### PR DESCRIPTION
This should make github notifications take less space in the matrix room. Everyone gets notified and invited to the discussion but not that much destructed.

Proposed solution for #72