### PR TITLE
Send message when a discussion is started.

### DIFF
--- a/.github/workflows/for-discussions.yml
+++ b/.github/workflows/for-discussions.yml
@@ -2,7 +2,7 @@ name: Notify matrix when a discussion is started
 
 on:
   discussion:
-      types: [opened, transferred]
+      types: [created, transferred]
 
 jobs:
   ping_matrix:


### PR DESCRIPTION
Problem: gh action was not triggered for discussion creation. 

The schema for gh actions lists 'opened' as an activity type where the doc uses 'created'. Let's try the other one...

https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#discussion